### PR TITLE
Updated git instructions in Meteor section

### DIFF
--- a/meteor/README.md
+++ b/meteor/README.md
@@ -17,7 +17,7 @@ Meteor is used to write applications that runs on both on the server and client 
 3. This guide assumes that you are using the official sample app [simple-todos-react](https://github.com/meteor/simple-todos-react). Clone the repo to get started
     > 
     ```
-    git git@github.com:meteor/simple-todos-react.git
+    git clone git@github.com:meteor/simple-todos-react.git
     cd simple-todos-react
     npm install
     code .


### PR DESCRIPTION
If you just copy and paste the first command from the README git will throw and error. 

I just changed the instructions to `git clone git@github.com:meteor/simple-todos-react.git` so that someone can just copy and paste it if needed. 