### PR TITLE
Update README.md to match current launch.json

### DIFF
--- a/debugging-jest-tests/README.md
+++ b/debugging-jest-tests/README.md
@@ -37,7 +37,7 @@ To try the example you'll need to install dependencies by running:
       "request": "launch",
       "name": "Jest Current File",
       "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-      "args": ["${file}"],
+      "args": ["${relativeFile}"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }


### PR DESCRIPTION
Jest Current File should use the args ${relativeFile} rather than ${file}