### PR TITLE
Added config to discover tests in any subdirectory

### DIFF
--- a/debugging-mocha-tests/README.md
+++ b/debugging-mocha-tests/README.md
@@ -55,6 +55,44 @@ To try the example you'll need to install dependencies by running:
 }
 ```
 
+If you don't have all of your tests under a common "test" directory, then the following configuration can be used. It will recursively search for all \*.test.js files except for those that are in a node_modules directory.
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+        "type": "node",
+        "request": "launch",
+        "name": "Mocha All",
+        "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+        "args": [
+            "--timeout",
+            "999999",
+            "--colors",
+            "'${workspaceFolder}/{,!(node_modules)/}*/*.test.js'"
+        ],
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen"
+    },
+    {
+        "type": "node",
+        "request": "launch",
+        "name": "Mocha Current File",
+        "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+        "args": [
+            "--timeout",
+            "999999",
+            "--colors",
+            "${file}"
+        ],
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}
+```
+
 ## Debugging all tests
 
 You can debug all tests by following the steps below:


### PR DESCRIPTION
A common practice is to have unit tests sitting next to the thing it tests. For example, https://medium.com/@JeffLombardJr/organizing-tests-in-jest-17fc431ff850 

It took me a while to get this working. This PR adds a section to the mocha readme that allows such test discovery while ignoring the ones inside node_modules folders.