### PR TITLE
jest debugging : fixed program path so it also works with jest-cli

### DIFF
--- a/debugging-jest-tests/README.md
+++ b/debugging-jest-tests/README.md
@@ -27,7 +27,7 @@ To try the example you'll need to install dependencies by running:
       "type": "node",
       "request": "launch",
       "name": "Jest All",
-      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": ["--runInBand"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
@@ -36,7 +36,7 @@ To try the example you'll need to install dependencies by running:
       "type": "node",
       "request": "launch",
       "name": "Jest Current File",
-      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": ["${relativeFile}"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"


### PR DESCRIPTION
As of today (06/18), if a VS code user uses react-boilerplate, [he will install jest-cli as a dev dependency](https://github.com/react-boilerplate/react-boilerplate/blob/1534dd508dbf1d0e9f781f7fe437ed217c1ed9a7/package.json#L283) and there won't be any `node_modules/jest` folder, and these two debug configurations won't work. 

So replaced the `program` path, so it uses `node_modules/.bin/jest` which will work when having either `jest` or `jest-cli` as a dev dependency.

It took me a little while to understand why these configs didn't work on my end even if they looked good, I hope this can save other VS Code users some time 🙂