### PR TITLE
added instructions for windows users

### DIFF
--- a/debugging-jest-tests/README.md
+++ b/debugging-jest-tests/README.md
@@ -30,7 +30,10 @@ To try the example you'll need to install dependencies by running:
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": ["--runInBand"],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      }
     },
     {
       "type": "node",
@@ -39,9 +42,20 @@ To try the example you'll need to install dependencies by running:
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": ["${relativeFile}"],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      }
     }
   ]
+}
+```
+
+**Note for windows users** : if `node_modules/jest` is not available in your project, but `node_modules/jest-cli` is installed (e.g. if you are [using react-boilerplate](https://github.com/react-boilerplate/react-boilerplate/blob/v3.6.0/package.json#L221)) you can replace the windows attribute by this one for both launch configurations :
+
+```json
+"windows": {
+  "program": "${workspaceFolder}/node_modules/jest-cli/bin/jest",
 }
 ```
 


### PR DESCRIPTION
This is a fix for https://github.com/Microsoft/vscode-recipes/issues/107

The current jest configuration doesn't actually work on windows (it's a weird VS code launch problem, running `./node_modules/.bin/jest` in a powershell in VS code **does** work).

So I 
- added a workaround configuration for windows users
- added a comment for windows users using `jest-cli` instead of `jest` so they know how to edit the config to make it work