### PR TITLE
Pull request for Jest issue - SecurityError: localStorage is not available for opaque origins #119

### DIFF
--- a/debugging-jest-tests/README.md
+++ b/debugging-jest-tests/README.md
@@ -51,6 +51,14 @@ To try the example you'll need to install dependencies by running:
 }
 ```
 
+## Configure package.json File for your test framework
+* Add following Jest configuration to package.json:
+```
+"jest": {
+   "testEnvironment": "node"
+}
+```
+
 **Note for windows users** : if `node_modules/jest` is not available in your project, but `node_modules/jest-cli` is installed (e.g. if you are [using react-boilerplate](https://github.com/react-boilerplate/react-boilerplate/blob/v3.6.0/package.json#L221)) you can replace the windows attribute by this one for both launch configurations :
 
 ```json

--- a/debugging-jest-tests/package.json
+++ b/debugging-jest-tests/package.json
@@ -9,5 +9,8 @@
   "license": "ISC",
   "dependencies": {
     "jest": "22.0.4"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
Pull request for Jest error - SecurityError: localStorage is not available for opaque origins #119

Jsdom just recently upgraded to version 11.12, which includes support for window.localStorage and other features. See https://github.com/jsdom/jsdom/blob/master/Changelog.md.

Jest does not raise above error when Node is specified as the test environment. 

Pull request raised to add above change to documentation if appropriate.

Please excuse any inconvenience I may cause. This is my first pull request on a public github repository.

Thanks.