### PR TITLE
add preLaunchTask to launch.json

### DIFF
--- a/Angular-CLI/README.md
+++ b/Angular-CLI/README.md
@@ -50,7 +50,8 @@ Then click on the gear icon to configure a launch.json file, selecting **Chrome*
         "type": "chrome",
         "request": "launch",
         "url": "http://localhost:4200/#",
-        "webRoot": "${workspaceFolder}"
+        "webRoot": "${workspaceFolder}",
+        "preLaunchTask": "ng serve"
       },
       {
         "name": "ng test",


### PR DESCRIPTION
Without the `preLaunchTask` the launch config will only open the chrome browser.