### PR TITLE
Update README.md launch.json section with npx

### DIFF
--- a/Next-js/README.md
+++ b/Next-js/README.md
@@ -51,8 +51,9 @@ Then click on the gear icon to configure a launch.json file, selecting **Chrome*
             "type": "node",
             "request": "launch",
             "name": "Next: Node",
-            "runtimeExecutable": "next",
+            "runtimeExecutable": "npx",
             "runtimeArgs": [
+                "next",
                 "--inspect"
             ],
             "port": 9229,


### PR DESCRIPTION
Usage of npx (recommended since npm 5.2.0) to launch nextjs binary instead of trying to launch it directly and being confronted to PATH issues