### PR TITLE
Add "skipFiles" option to README.md & launch.json

### DIFF
--- a/Docker-TypeScript/.vscode/launch.json
+++ b/Docker-TypeScript/.vscode/launch.json
@@ -47,6 +47,9 @@
       "remoteRoot": "/server",
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
+      ],
+      "skipFiles": [
+        "<node_internals>/**/*.js",
       ]
     },
     {

--- a/Docker-TypeScript/README.md
+++ b/Docker-TypeScript/README.md
@@ -180,6 +180,9 @@ For attaching the VS Code node debugger to the server running in the Docker cont
       "remoteRoot": "/server",
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
+      ],
+      "skipFiles": [
+        "<node_internals>/**/*.js",
       ]
     }
   ]
@@ -221,6 +224,9 @@ Instead of launching Docker from the command line and then attaching the debugge
       "remoteRoot": "/server",
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
+      ],
+      "skipFiles": [
+        "<node_internals>/**/*.js",
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"


### PR DESCRIPTION
When I was testing the Docker-TypeScript, I realised that option to skipFiles was not instructed. 
My debugger went through all the execution methods inside Express which was not really needed. 

I added the option to launch.json and in the README.md so that people are aware that it is an option when debugging inside Docker with vscode. 