### PR TITLE
Clean up markdown formatting for the Python recipe

### DIFF
--- a/debugging python/README.md
+++ b/debugging python/README.md
@@ -6,9 +6,9 @@ This recipe shows how to debug a Python application using the VS Code extension 
 
 ## Getting Started
 
-1. Make sure you have the latest version of [VS Code](https://code.visualstudio.com/) installed. 
+1. Make sure you have the latest version of [VS Code](https://code.visualstudio.com/) installed.
 
-2. Make sure you have the extension [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) installed. 
+2. Make sure you have the extension [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) installed.
 
 3. Optionally you can also install a linter to throw out the errors.
 
@@ -19,110 +19,112 @@ This recipe shows how to debug a Python application using the VS Code extension 
 
 2. Then click on the gear icon to configure a launch.json file, select **Launch** for the environment.
 
-3. YOu may get an option of the environments available, select **Python**.
-    
+3. You may get an option of the environments available, select **Python**.
+
 4. The generated json will have a lot of the configurations. You can keep all of them or only the ones you want.
 
     ```json
-   {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Python: Current File (Integrated Terminal)",
-            "type": "python",
-            "request": "launch",
-            "program": "${file}",
-            "console": "integratedTerminal"
-        },
-        {
-            "name": "Python: Attach",
-            "type": "python",
-            "request": "attach",
-            "port": 5678,
-            "host": "localhost"
-        },
-        {
-            "name": "Python: Module",
-            "type": "python",
-            "request": "launch",
-            "module": "enter-your-module-name-here",
-            "console": "integratedTerminal"
-        },
-        {
-            "name": "Python: Django",
-            "type": "python",
-            "request": "launch",
-            "program": "${workspaceFolder}/manage.py",
-            "console": "integratedTerminal",
-            "args": [
-                "runserver",
-                "--noreload",
-                "--nothreading"
-            ],
-            "django": true
-        },
-        {
-            "name": "Python: Flask",
-            "type": "python",
-            "request": "launch",
-            "module": "flask",
-            "env": {
-                "FLASK_APP": "app.py"
+    {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Python: Current File (Integrated Terminal)",
+                "type": "python",
+                "request": "launch",
+                "program": "${file}",
+                "console": "integratedTerminal"
             },
-            "args": [
-                "run",
-                "--no-debugger",
-                "--no-reload"
-            ],
-            "jinja": true
-        },
-        {
-            "name": "Python: Current File (External Terminal)",
-            "type": "python",
-            "request": "launch",
-            "program": "${file}",
-            "console": "externalTerminal"
-        }]
-    }   
+            {
+                "name": "Python: Attach",
+                "type": "python",
+                "request": "attach",
+                "port": 5678,
+                "host": "localhost"
+            },
+            {
+                "name": "Python: Module",
+                "type": "python",
+                "request": "launch",
+                "module": "enter-your-module-name-here",
+                "console": "integratedTerminal"
+            },
+            {
+                "name": "Python: Django",
+                "type": "python",
+                "request": "launch",
+                "program": "${workspaceFolder}/manage.py",
+                "console": "integratedTerminal",
+                "args": [
+                    "runserver",
+                    "--noreload",
+                    "--nothreading"
+                ],
+                "django": true
+            },
+            {
+                "name": "Python: Flask",
+                "type": "python",
+                "request": "launch",
+                "module": "flask",
+                "env": {
+                    "FLASK_APP": "app.py"
+                },
+                "args": [
+                    "run",
+                    "--no-debugger",
+                    "--no-reload"
+                ],
+                "jinja": true
+            },
+            {
+                "name": "Python: Current File (External Terminal)",
+                "type": "python",
+                "request": "launch",
+                "program": "${file}",
+                "console": "externalTerminal"
+            }
+        ]
+    }
     ```
-    
+
 5. For basic Python debugging of files, you will only need the following configuration:
-    ```json
-        {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Python: Current File (Integrated Terminal)",
-            "type": "python",
-            "request": "launch",
-            "program": "${file}",
-            "console": "integratedTerminal"
-        },
-        {
-            "name": "Python: Current File (External Terminal)",
-            "type": "python",
-            "request": "launch",
-            "program": "${file}",
-            "console": "externalTerminal"
-        }]
+    ```js
+    {
+        // Use IntelliSense to learn about possible attributes.
+        // Hover to view descriptions of existing attributes.
+        // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Python: Current File (Integrated Terminal)",
+                "type": "python",
+                "request": "launch",
+                "program": "${file}",
+                "console": "integratedTerminal"
+            },
+            {
+                "name": "Python: Current File (External Terminal)",
+                "type": "python",
+                "request": "launch",
+                "program": "${file}",
+                "console": "externalTerminal"
+            }
+        ]
     }
     ```
 
 ## Start Debugging.
-  
+
 1. Open your Python file in VS Code.
 
-2. Go to the Debug view, select the **Start Debugging** then press F5 or click the green play button.
+2. Go to the Debug view, select the **Start Debugging** then press <kbd>F5</kbd> or click the green play button.
 
 3. VS Code should now show the rails server logs.
 
 4. Go ahead and set a breakpoint in any of the files by clicking on the space before the line number. A red dot should appear to show a breakpoint.
 
-5. Press F5 to start debugging.
+5. Press <kbd>F5</kbd> to start debugging.
 
 6. Your breakpoint should now be hit.
 
-7. To continue, press F5 again, till you reach the end.
+7. To continue, press <kbd>F5</kbd> again, till you reach the end.


### PR DESCRIPTION
This addresses the following:

- Cleans up some minor typos
- Normalizes the json code blocks
- Removes unnecessary whitespace characters
- Wraps `kbd` tags around instructions containing a plain text `F5`

Note that for the `json` code block with comments – step 5 of the configure section, I changed the language to `js` so that the comments would render properly.