### PR TITLE
Possible wrong path for sourceMapPathOverrides

### DIFF
--- a/vuejs-cli/README.md
+++ b/vuejs-cli/README.md
@@ -80,7 +80,7 @@ Then click on the gear icon to configure a launch.json file, selecting **Chrome*
       "webRoot": "${workspaceFolder}/src",
       "breakOnLoad": true,
       "sourceMapPathOverrides": {
-        "webpack:///src/*": "${webRoot}/*"
+        "webpack:///./src/*": "${webRoot}/*"
       }
     }
   ]


### PR DESCRIPTION
Hey folks! I hope everyone is doing well today.

I was working with the default TypeScript project from the Vue CLI 3, and I could not for the life of me get VS Code debugging to work. Then I noticed that it appeared that WebPack was serving up its files from a different directory than what VS Code is looking at. 

Chrome serves up files from `webpack:///./src/*`. 

If I change the launch config to match that pattern, it works. As is the "./" is missing in the launch config. Could it be that we need to modify that in order for this to work?

Here is [my reproduction of the issue](https://github.com/burkeholland/vue-vs-code-typescript) so you can see exact lib versions and what not. High level - Vue CLI 3 TypeScript template (with classes).

I also tested the JavaScript (Babel) version (the "default" option from the Vue CLI) and it seems to require this same tweak.