### PR TITLE
Fix type for isBackground in Angular-CLI

### DIFF
--- a/Angular-CLI/README.md
+++ b/Angular-CLI/README.md
@@ -94,7 +94,7 @@ Then click on the gear icon to configure a launch.json file, selecting **Chrome*
       {
         "type": "npm",
         "script": "start",
-        "isBackground": "true",
+        "isBackground": true,
         "presentation": {
           "focus": true,
           "panel": "dedicated"


### PR DESCRIPTION
Hi there,

I noticed `isBackground` in tasks.json was treated as a string in the Angular-CLI instructions, corrected this to be boolean [as specified in the docs](https://code.visualstudio.com/docs/editor/tasks-appendix).

Thanks! 👍 