### PR TITLE
Fix "No tests found" after update VSCode to 1.32.1

### DIFF
--- a/debugging-jest-tests/README.md
+++ b/debugging-jest-tests/README.md
@@ -42,7 +42,7 @@ To try the example you'll need to install dependencies by running:
       "name": "Jest Current File",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": [
-        "${relativeFile}",
+        "${fileBasenameNoExtension}",
         "--config",
         "jest.config.js"
       ],


### PR DESCRIPTION
Jest can't find test files because VSCode changed their `${relativeFile}` seperator from `\\` to `\`

See https://stackoverflow.com/questions/55095712/jest-no-tests-found-after-update-vscode-to-1-32-1