### PR TITLE
Rollback path change

### DIFF
--- a/vuejs-cli/README.md
+++ b/vuejs-cli/README.md
@@ -80,7 +80,7 @@ Then click on the gear icon to configure a launch.json file, selecting **Chrome*
       "webRoot": "${workspaceFolder}/src",
       "breakOnLoad": true,
       "sourceMapPathOverrides": {
-        "webpack:///./src/*": "${webRoot}/*"
+        "webpack:///src/*": "${webRoot}/*"
       }
     }
   ]


### PR DESCRIPTION
This rolls back the path change that turns src into ./src. This breaks debugging.