### PR TITLE
fix(jest): current file launch config on Windows

### DIFF
--- a/debugging-jest-tests/.vscode/launch.json
+++ b/debugging-jest-tests/.vscode/launch.json
@@ -20,6 +20,7 @@
       "name": "Jest Current File",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": [
+        "--runTestsByPath",
         "${relativeFile}",
         "--config",
         "jest.config.js"

--- a/debugging-jest-tests/README.md
+++ b/debugging-jest-tests/README.md
@@ -42,7 +42,8 @@ To try the example you'll need to install dependencies by running:
       "name": "Jest Current File",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": [
-        "${fileBasenameNoExtension}",
+        "--runTestsByPath",
+        "${relativeFile}",
         "--config",
         "jest.config.js"
       ],


### PR DESCRIPTION
This commit adds the [`--runTestsByPath`](https://jestjs.io/docs/en/cli#runtestsbypath) flag which fixes an issue with
using `${relativeFile}` on Windows.

I tested this on Windows and Mac. Would love if someone could test on Linux!

<details>
<summary>Windows version info</summary>

```
Version: 1.38.1 (user setup)
Commit: b37e54c98e1a74ba89e03073e5a3761284e3ffb0
Date: 2019-09-11T13:35:15.005Z
Electron: 4.2.10
Chrome: 69.0.3497.128
Node.js: 10.11.0
V8: 6.9.427.31-electron.0
OS: Windows_NT x64 10.0.17763
```
</details>

<details>
<summary>Mac version info</summary>

```
Version: 1.38.1
Commit: b37e54c98e1a74ba89e03073e5a3761284e3ffb0
Date: 2019-09-11T13:31:32.854Z
Electron: 4.2.10
Chrome: 69.0.3497.128
Node.js: 10.11.0
V8: 6.9.427.31-electron.0
OS: Darwin x64 18.7.0
```
</details>

Closes [#205](https://github.com/microsoft/vscode-recipes/issues/205#issuecomment-533645097)