### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/Angular-SpaTemplates/README.md
+++ b/Angular-SpaTemplates/README.md
@@ -10,7 +10,7 @@ This recipe shows how to use both the [Debugger for Chrome](https://github.com/M
 
 - Version **3.5.0** or greater of the [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) extension installed in VS Code.
 
-- Version **1.13.1** of the [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) extension installed in VS Code.
+- Version **1.13.1** of the [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extension installed in VS Code.
 
 - .NET Core SDK 1.0 RC4 (or later) for Windows, Mac, or Linux
 
@@ -31,7 +31,7 @@ This recipe shows how to use both the [Debugger for Chrome](https://github.com/M
     ```
     mkdir my-app
     cd my-app
-    dotnet new amgular
+    dotnet new angular
     ```
 
 - Restore dependencies

--- a/debugging-cake-scripts/README.md
+++ b/debugging-cake-scripts/README.md
@@ -10,7 +10,7 @@ This guide will use the [Cake example project](https://github.com/cake-build/exa
 
 Make sure you have the following already in place:
 
-- The latest version of the [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) extension installed in VS Code.
+- The latest version of the [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extension installed in VS Code.
 
 - Also make sure you have the latest version of the [Cake for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=cake-build.cake-vscode) extension installed.
 


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp".

Also fixed a typo `amgular` -> `angular`.