### PR TITLE
Ajustements last version mocha use configuration file instead opts

### DIFF
--- a/debugging-mocha-tests/.vscode/launch.json
+++ b/debugging-mocha-tests/.vscode/launch.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.0",
+    "version": "0.2.1",
     "configurations": [
         {
             "type": "node",

--- a/debugging-mocha-tests/README.md
+++ b/debugging-mocha-tests/README.md
@@ -105,17 +105,18 @@ If you don't have all of your tests under a common "test" directory, then the fo
 }
 ```
 
-If you are running mocha will multiple arguments, you may consider creating an opt file that store all these arguments (i.e name it as mocha.opts).
+If you are running mocha will multiple arguments, you may consider creating an opt file that store all these arguments (i.e name it as mocha.json).
 
-Example file contents with mocha arguments: 
+Example file contents with mocha arguments:
 
+```json
+{
+  "colors": true,
+  "timeout": 999999
+}
 ```
---timeout 999999
---colors
---full-trace  
-```
 
-Reference the mocha opts file with --opts in configuration as shown below
+Reference the mocha config file with --config in configuration as shown below
 
 ```json
 {
@@ -127,8 +128,8 @@ Reference the mocha opts file with --opts in configuration as shown below
             "name": "Mocha Test All with Options",
             "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
             "args": [
-                "--opts", 
-                "${workspaceFolder}/support/mocha.opts",
+                "--config",
+                "${workspaceFolder}/support/mocha.json",
                 "${workspaceFolder}/test"
             ],
             "console": "integratedTerminal",
@@ -140,6 +141,8 @@ Reference the mocha opts file with --opts in configuration as shown below
     ]
 }
 ```
+
+Mocha supports [many configuration](https://mochajs.org/#configuring-mocha-nodejs), typical of modern command-line tools.
 
 ## Debugging all tests
 

--- a/debugging-mocha-tests/README.md
+++ b/debugging-mocha-tests/README.md
@@ -167,3 +167,16 @@ You can debug the test you're editing by following the steps below:
 3. Your breakpoint will now be hit
 
 ![current](current.gif)
+
+## Tips
+
+If you be warned by `Configured debug type 'pwa-node' is not supported.` in VSCode
+
+Update the content of the `.vscode/settings.json` with the following configurations:
+
+```json
+{
+  "debug.chrome.useV3": true,
+  "debug.javascript.usePreview": false
+}
+```

--- a/debugging-mocha-tests/package.json
+++ b/debugging-mocha-tests/package.json
@@ -6,9 +6,12 @@
     "test": "mocha 'test/**/*.spec.js'"
   },
   "author": "Jag Reehal",
+  "contributors": [
+    "Alfred Dagenais <jesuis@alfreddagenais.com> (https://www.alfreddagenais.com)"
+  ],
   "license": "ISC",
   "dependencies": {
-    "chai": "4.1.2",
-    "mocha": "4.1.0"
+    "chai": "4.2.0",
+    "mocha": "8.1.3"
   }
 }

--- a/debugging-mocha-tests/support/mocha.json
+++ b/debugging-mocha-tests/support/mocha.json
@@ -1,0 +1,4 @@
+{
+  "colors": true,
+  "timeout": 999999
+}

--- a/debugging-mocha-tests/support/mocha.opts
+++ b/debugging-mocha-tests/support/mocha.opts
@@ -1,2 +1,0 @@
---timeout 999999
---colors


### PR DESCRIPTION
I remove file `mocha.opts` use the `--opts` parameters removed in v8.0.0. I update to use [configuration](https://mochajs.org/#configuring-mocha-nodejs) file instead.

I update `mocha` and `chai` to the last version